### PR TITLE
Add mipsel-unknown-linux-musl build in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,9 @@ runs:
     - name: Install Rust Toolchain Components
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        target: ${{ matrix.target }}
+        toolchain: ${{ matrix.toolchain || 'stable' }}
+        target: ${{ matrix.build-std && 'x86_64-unknown-linux-gnu' || matrix.target }}
+        components: ${{ matrix.build-std && 'rust-src' || '' }}
 
     - name: Install just
       uses: extractions/setup-just@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,11 @@ jobs:
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest
             archive: tar.gz tar.xz tar.zst
-          # - target: mips-unknown-linux-musl
-          #   archive: tar.gz tar.xz tar.zst
+          - target: mipsel-unknown-linux-musl
+            os: ubuntu-latest
+            toolchain: nightly
+            build-std: true
+            archive: tar.gz tar.xz tar.zst
           # - target: mips-unknown-linux-musl
           #   archive: tar.gz tar.xz tar.zst
           # - target: mips64-unknown-linux-muslabi64

--- a/Cross.toml
+++ b/Cross.toml
@@ -12,3 +12,7 @@ image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main"
 
 [target.aarch64-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+
+[target.mipsel-unknown-linux-musl]
+image = "ghcr.io/cross-rs/mipsel-unknown-linux-musl:main"
+build-std = true


### PR DESCRIPTION
Tested on router with mipsel arch (Mediatek MT7621 SoC) on OpenWRT 24.10.3